### PR TITLE
fix contract scaffold path

### DIFF
--- a/auto_dev/contracts/contract.py
+++ b/auto_dev/contracts/contract.py
@@ -56,7 +56,9 @@ class Contract:
         self.name = name
         self.abi = abi
         self.address = address
+        # Store files in contracts/ but maintain package imports for sys.path compatibility
         self.path = Path.cwd() / "contracts" / self.name
+        self.package_path = f"packages.{self.author}.contracts.{self.name}"
         self.web3 = web3 if web3 is not None else Web3(Web3.HTTPProvider("http://127.0.0.1:8545"))
 
     def write_abi_to_file(self) -> None:
@@ -104,7 +106,7 @@ class Contract:
         )
         contract_py = contract_py.replace(
             "from aea.configurations.base import PublicId",
-            f"from contracts.{self.name} import PUBLIC_ID",
+            f"from {self.package_path} import PUBLIC_ID",
         )
 
         contract_py = contract_py.replace(

--- a/auto_dev/contracts/contract.py
+++ b/auto_dev/contracts/contract.py
@@ -56,7 +56,7 @@ class Contract:
         self.name = name
         self.abi = abi
         self.address = address
-        self.path = Path.cwd() / "packages" / self.author / "contracts" / self.name
+        self.path = Path.cwd() / "contracts" / self.name
         self.web3 = web3 if web3 is not None else Web3(Web3.HTTPProvider("http://127.0.0.1:8545"))
 
     def write_abi_to_file(self) -> None:
@@ -104,7 +104,7 @@ class Contract:
         )
         contract_py = contract_py.replace(
             "from aea.configurations.base import PublicId",
-            f"from packages.{self.author}.contracts.{self.name} import PUBLIC_ID",
+            f"from contracts.{self.name} import PUBLIC_ID",
         )
 
         contract_py = contract_py.replace(


### PR DESCRIPTION
# Fix Contract Scaffolding Path

## Changes
- Modified Contract class to create contracts directly in `contracts/` directory instead of `packages/{author}/contracts/`
- Updated import path in contract.py to reflect new directory structure
- Aligns contract scaffolding behavior with existing protocol and connection scaffolding


new: 
1. Keep contracts in contracts/ directory for consistent scaffolding
2. Maintain package-style imports using packages.{author}.contracts.{name}
3. Added package_path attribute to manage import paths correctly

## Testing
- Existing tests pass without modification as they already expected the correct path structure
- CI will verify the changes