### PR TITLE
Fix 'package' typo

### DIFF
--- a/auto_dev/commands/create.py
+++ b/auto_dev/commands/create.py
@@ -157,7 +157,7 @@ def create(ctx, public_id: str, template: str, force: bool, publish: bool, clean
         # We check if there is a local registry.
 
         if not Path("packages").exists():
-            command = CommandExecutor("autonomy package init")
+            command = CommandExecutor(["poetry", "run", "autonomy", "packages", "init"])
             result = command.execute(verbose=verbose)
             if not result:
                 msg = f"Command failed: {command.command}"

--- a/docs/fsm.md
+++ b/docs/fsm.md
@@ -66,7 +66,7 @@ graph TD
 We now scaffold the agent.
 
 ```bash
-adev create -t eightballer/base author/new_agent
+adev create --no-clean-up -t eightballer/base author/new_agent
 ```
 We now have a new agent.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,3 +59,14 @@ def test_create_valid_names(cli_runner, test_packages_filesystem):
         runner = cli_runner(cmd)
         assert runner.execute()
         assert runner.return_code == 0, f"Command failed for valid name '{name}': {runner.output}"
+
+
+def test_create_with_publish_no_packages(cli_runner, test_filesystem):
+    """Test the create command succeeds when there is no local packages directory."""
+    assert str(Path.cwd()) == test_filesystem
+    cmd = ["adev", "-v", "create", f"{DEFAULT_AUTHOR}/test_agent", "-t", "eightballer/base"]
+
+    runner = cli_runner(cmd)
+    assert runner.execute()
+    assert "No such file or directory" not in runner.output
+    assert runner.return_code == 0, f"Command failed': {runner.output}"


### PR DESCRIPTION
Executing: `adev create -t eightballer/base author/new_agent`

Output:
```
[2025-01-07 11:56:28,465][INFO] Starting Auto Dev v0.2.80 ...
[2025-01-07 11:56:28,465][INFO] Using 10 processes for processing
[2025-01-07 11:56:28,465][INFO] Setting log level to INFO
[2025-01-07 11:56:28,466][INFO] Creating agent new_agent from template eightballer/base
Executing command: ['poetry', 'run', 'autonomy', 'fetch', 'bafybeidohldv57m3jkc33zpgbxukaushmcibmt4ncnsnomd3pvpocxs3ui', '--alias', 'new_agent']
Command executed successfully.
Updating author in aea-config.yaml from eightballer to author
[2025-01-07 11:56:51,269][ERROR] Command failed: [Errno 2] No such file or directory: 'autonomy package init'
Traceback (most recent call last):
  File "/private/var/folders/d1/6xbmlpm5321bvqsnynh2nph00000gn/T/tmplfy0syp6/auto_dev/cli_executor.py", line 36, in execute
    result = subprocess.run(
             ^^^^^^^^^^^^^^^
  File "/Users/user/.pyenv/versions/3.11.8/lib/python3.11/subprocess.py", line 548, in run
    with Popen(*popenargs, **kwargs) as process:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/.pyenv/versions/3.11.8/lib/python3.11/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/Users/user/.pyenv/versions/3.11.8/lib/python3.11/subprocess.py", line 1953, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'autonomy package init'
Command failed: autonomy package init
```