### PR TITLE
add 3.11 error

### DIFF
--- a/auto_dev/handler/openapi_models.py
+++ b/auto_dev/handler/openapi_models.py
@@ -25,7 +25,7 @@ class Reference(BaseModel):
         return current
 
 
-class DataType(enum.StrEnum):
+class DataType(enum.Enum):
     """Data type."""
 
     STRING = "string"
@@ -34,6 +34,9 @@ class DataType(enum.StrEnum):
     BOOLEAN = "boolean"
     ARRAY = "array"
     OBJECT = "object"
+
+    def __str__(self):
+        return self.value
 
 
 class Schema(BaseModel):


### PR DESCRIPTION
fixes error:

(getting this on python 3.11)

File "/Users/.../Desktop/auto_dev/auto_dev/handler/openapi_utils.py", line 10, in
from auto_dev.handler.openapi_models import Schema, OpenAPI, Operation, Reference
File "/Users/.../Desktop/auto_dev/auto_dev/handler/openapi_models.py", line 28, in
class DataType(enum.StrEnum):
AttributeError: module 'enum' has no attribute 'StrEnum'