### PR TITLE
Refine codegen & protocol enum extraction, Pydantic/Hypothesis compatibility, scoped rebuild

### DIFF
--- a/auto_dev/constants.py
+++ b/auto_dev/constants.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from aea.cli.utils.config import get_or_create_cli_config
 from aea.configurations.data_types import PublicId
 
+PKG_ROOT = Path(__file__).parent
 
 DEFAULT_ENCODING = "utf-8"
 DEFAULT_TZ = "UTC"

--- a/auto_dev/constants.py
+++ b/auto_dev/constants.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from aea.cli.utils.config import get_or_create_cli_config
 from aea.configurations.data_types import PublicId
 
+
 PKG_ROOT = Path(__file__).parent
 
 DEFAULT_ENCODING = "utf-8"

--- a/auto_dev/data/templates/protocols/hypothesis.jinja
+++ b/auto_dev/data/templates/protocols/hypothesis.jinja
@@ -22,14 +22,9 @@ from {{ import_paths.models }} import (
     {%- endfor %}
 )
 
-{# Define strategies for each message #}
-{%- for message in file.messages %}
-{{ message.name|lower }}_strategy = st.from_type({{ message.name }})
-{%- endfor %}
-
 {# Define tests for each message #}
 {%- for message in file.messages %}
-@given({{ message.name|lower }}_strategy)
+@given(st.from_type({{ message.name }}))
 def test_{{ message.name|lower }}({{ message.name|lower }}: {{ message.name }}):
     """Test {{ message.name }}"""
     assert isinstance({{ message.name|lower }}, {{ message.name }})

--- a/auto_dev/data/templates/protocols/hypothesis.jinja
+++ b/auto_dev/data/templates/protocols/hypothesis.jinja
@@ -31,6 +31,5 @@ def test_{{ message.name|lower }}({{ message.name|lower }}: {{ message.name }}):
     proto_obj = {{ messages_pb2 }}.{{ message.name }}()
     {{ message.name|lower }}.encode(proto_obj, {{ message.name|lower }})
     result = {{ message.name }}.decode(proto_obj)
-    assert id({{ message.name|lower }}) != id(result)
     assert {{ message.name|lower }} == result
 {% endfor %}

--- a/auto_dev/data/templates/protocols/performatives.jinja
+++ b/auto_dev/data/templates/protocols/performatives.jinja
@@ -2,6 +2,8 @@
 
 """Models for the {{ snake_name }} protocol performatives to facilitate hypothesis strategy generation."""
 
+from typing import Optional
+
 from pydantic import BaseModel, conint, confloat
 
 from packages.{{ author }}.protocols.{{ snake_name }}.tests.primitive_strategies import (

--- a/auto_dev/data/templates/protocols/performatives.jinja
+++ b/auto_dev/data/templates/protocols/performatives.jinja
@@ -31,5 +31,6 @@ class {{ snake_to_camel(performative) }}(BaseModel):
 
 {% endfor %}
 
-for cls in BaseModel.__subclasses__():
-    cls.model_rebuild()
+{%- for performative in performative_types %}
+{{ snake_to_camel(performative) }}.model_rebuild()
+{%- endfor %}

--- a/auto_dev/data/templates/protocols/performatives.jinja
+++ b/auto_dev/data/templates/protocols/performatives.jinja
@@ -16,6 +16,11 @@ from packages.{{ author }}.protocols.{{ snake_name }}.custom_types import (
     {%- endfor %}
 )
 
+
+# ruff: noqa: UP007
+# UP007    - Use X | Y for type annotations  # NOTE: important edge case pydantic-hypothesis interaction!
+
+
 {# Define models for the performatives #}
 {%- for performative, fields in performative_types.items() %}
 class {{ snake_to_camel(performative) }}(BaseModel):

--- a/auto_dev/data/templates/protocols/protodantic.jinja
+++ b/auto_dev/data/templates/protocols/protodantic.jinja
@@ -16,13 +16,14 @@ from {{ import_paths.primitives }} import (
     {%- endfor %}
 )
 
-# ruff: noqa: N806, C901, PLR0912, PLR0914, PLR0915, A001
+# ruff: noqa: N806, C901, PLR0912, PLR0914, PLR0915, A001, UP007
 # N806     - variable should be lowercase
 # C901     - function is too complex
 # PLR0912  - too many branches
 # PLR0914  - too many local variables
 # PLR0915  - too many statements
 # A001     - shadowing builtin names like `id` and `type`
+# UP007    - Use X | Y for type annotations  # NOTE: important edge case pydantic-hypothesis interaction!
 
 MAX_PROTO_SIZE = 2 * 1024 * 1024 * 1024  # 2 GiB in bytes
 

--- a/auto_dev/data/templates/protocols/protodantic.jinja
+++ b/auto_dev/data/templates/protocols/protodantic.jinja
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from enum import IntEnum
+from typing import Optional
 
 from pydantic import BaseModel
 

--- a/auto_dev/data/templates/protocols/protodantic.jinja
+++ b/auto_dev/data/templates/protocols/protodantic.jinja
@@ -29,5 +29,7 @@ MAX_PROTO_SIZE = 2 * 1024 * 1024 * 1024  # 2 GiB in bytes
 
 {{ formatter.render(file) }}
 
-for cls in BaseModel.__subclasses__():
-    cls.model_rebuild()
+
+{%- for message in file.messages %}
+{{ message.name }}.model_rebuild()
+{%- endfor %}

--- a/auto_dev/data/templates/protocols/test_dialogues.jinja
+++ b/auto_dev/data/templates/protocols/test_dialogues.jinja
@@ -24,7 +24,7 @@ from packages.{{ author }}.protocols.{{ snake_name }}.tests.performatives import
 def shallow_dump(model: BaseModel) -> dict:
     """Shallow dump pydantic model."""
 
-    return {name: getattr(model, name) for name in model.__fields__}
+    return {name: getattr(model, name) for name in model.__class__.model_fields}
 
 
 def validate_dialogue(performative, model):

--- a/auto_dev/data/templates/protocols/test_messages.jinja
+++ b/auto_dev/data/templates/protocols/test_messages.jinja
@@ -28,7 +28,7 @@ from packages.{{ author }}.protocols.{{ snake_name }}.tests.performatives import
 def shallow_dump(model: BaseModel) -> dict:
     """Shallow dump pydantic model."""
 
-    return {name: getattr(model, name) for name in model.__fields__}
+    return {name: getattr(model, name) for name in model.__class__.model_fields}
 
 
 def perform_message_test(performative, model) -> None:

--- a/auto_dev/protocols/formatter.py
+++ b/auto_dev/protocols/formatter.py
@@ -68,7 +68,7 @@ def render_field(field: Field, message: MessageAdapter) -> str:
         case FieldCardinality.REQUIRED | None:
             return f"{resolved_type}"
         case FieldCardinality.OPTIONAL:
-            return f"Optional[{resolved_type}]"
+            return f"Optional[{resolved_type}] = None"
         case FieldCardinality.REPEATED:
             return f"list[{resolved_type}]"
         case _:

--- a/auto_dev/protocols/formatter.py
+++ b/auto_dev/protocols/formatter.py
@@ -68,7 +68,7 @@ def render_field(field: Field, message: MessageAdapter) -> str:
         case FieldCardinality.REQUIRED | None:
             return f"{resolved_type}"
         case FieldCardinality.OPTIONAL:
-            return f"{resolved_type} | None"
+            return f"Optional[{resolved_type}]"
         case FieldCardinality.REPEATED:
             return f"list[{resolved_type}]"
         case _:

--- a/auto_dev/protocols/performatives.py
+++ b/auto_dev/protocols/performatives.py
@@ -41,7 +41,7 @@ def parse_annotation(annotation: str) -> str:
 
     if core.startswith("optional[") and core.endswith("]"):
         inner = core[len("optional[") : -1]
-        return f"{parse_annotation(inner)} | None"
+        return f"Optional[{parse_annotation(inner)}]"
     if core.startswith("list[") and core.endswith("]"):
         inner = core[len("list[") : -1]
         return f"tuple[{parse_annotation(inner)}]"  # quirk of the framework!

--- a/auto_dev/protocols/protodantic.py
+++ b/auto_dev/protocols/protodantic.py
@@ -12,7 +12,7 @@ from jinja2 import Template, Environment, FileSystemLoader
 from pydantic import BaseModel, ConfigDict
 from proto_schema_parser.parser import Parser
 
-from auto_dev.constants import JINJA_TEMPLATE_FOLDER, PKG_ROOT
+from auto_dev.constants import PKG_ROOT, JINJA_TEMPLATE_FOLDER
 from auto_dev.protocols import formatter, primitives as primitives_module
 from auto_dev.protocols.adapters import FileAdapter
 

--- a/auto_dev/protocols/protodantic.py
+++ b/auto_dev/protocols/protodantic.py
@@ -12,7 +12,7 @@ from jinja2 import Template, Environment, FileSystemLoader
 from pydantic import BaseModel, ConfigDict
 from proto_schema_parser.parser import Parser
 
-from auto_dev.constants import JINJA_TEMPLATE_FOLDER
+from auto_dev.constants import JINJA_TEMPLATE_FOLDER, PKG_ROOT
 from auto_dev.protocols import formatter, primitives as primitives_module
 from auto_dev.protocols.adapters import FileAdapter
 
@@ -118,9 +118,9 @@ def _get_locally_defined_classes(module: ModuleType) -> list[type]:
     return list(filter(locally_defined, vars(module).values()))
 
 
-def copy_primitives(repo_root: Path, code_outpath: Path) -> Path:
+def copy_primitives(pkg_root: Path, code_outpath: Path) -> Path:
     """Copy primitives."""
-    primitives_py = repo_root / "auto_dev" / "protocols" / "primitives.py"
+    primitives_py = pkg_root / "protocols" / "primitives.py"
     primitives_outpath = code_outpath.parent / primitives_py.name
     primitives_outpath.write_text(primitives_py.read_text())
     return primitives_outpath
@@ -167,7 +167,7 @@ def create(
     jinja_templates = JinjaTemplates.load()
 
     # Copy primitives file
-    primitives_outpath = copy_primitives(repo_root, code_outpath)
+    primitives_outpath = copy_primitives(PKG_ROOT, code_outpath)
 
     # import the custom primitive types
     float_primitives, integer_primitives = _extract_primitives(primitives_module)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -79,7 +79,7 @@ def test_protodantic(proto_path: Path):
         ("pt:int", "conint(ge=Int32.min(), le=Int32.max())"),
         ("pt:float", "confloat(ge=Double.min(), le=Double.max())"),
         ("pt:list[pt:int]", "tuple[conint(ge=Int32.min(), le=Int32.max())]"),
-        ("pt:optional[pt:int]", "conint(ge=Int32.min(), le=Int32.max()) | None"),
+        ("pt:optional[pt:int]", "Optional[conint(ge=Int32.min(), le=Int32.max())]"),
         ("pt:dict[pt:str, pt:int]", "dict[str, conint(ge=Int32.min(), le=Int32.max())]"),
         (
             "pt:list[pt:union[pt:dict[pt:str, pt:int], pt:list[pt:bytes]]]",
@@ -87,7 +87,7 @@ def test_protodantic(proto_path: Path):
         ),
         (
             "pt:optional[pt:dict[pt:union[pt:str, pt:int], pt:list[pt:union[pt:float, pt:bool]]]]",
-            "dict[str | conint(ge=Int32.min(), le=Int32.max()), tuple[confloat(ge=Double.min(), le=Double.max()) | bool]] | None",  # noqa: E501
+            "Optional[dict[str | conint(ge=Int32.min(), le=Int32.max()), tuple[confloat(ge=Double.min(), le=Double.max()) | bool]]]",  # noqa: E501
         ),
     ],
 )


### PR DESCRIPTION
- Replace ad-hoc `get_repo_root()` calls with a single `THIS_PKG` constant
- Disable PEP 604 (`X | None`) rewrites on optional `data` fields to avoid Pydantic + Hypothesis conflicts
- Swap out `deprecated .__fields__` for the new model_fields API
- Restrict `model_rebuild()` invocations to only locally-defined `BaseModel` subclasses
- Introduce extraction of “enum-only” messages: flatten any message wrapping a single `IntEnum` into a top-level enum with `encode`/`decode`
- Perform an AST-driven rewrite of the remaining code to update all references to the new enums without touching other generated classes